### PR TITLE
Show selected rows correctly when multi-selecting

### DIFF
--- a/src/mixins/flatten.js
+++ b/src/mixins/flatten.js
@@ -26,7 +26,10 @@ export default {
                 .reduce((flattenedRows, row) => {
                     return flattenedRows.concat([
                         row,
-                        ...(row && row._showChildren ? this.flatten(row._meta.visibleChildren) : []),
+                        ...(row && row._showChildren ? this.flatten(row._meta.visibleChildren.map((row) => ({
+                            ...row,
+                            _isChildren: true,
+                        }))) : []),
                     ]);
                 }, []);
         },


### PR DESCRIPTION
# Description of the problem:
Incorrect row selection. Problem with incorrectly selected interval when using the Shift key during rows selection.

# Steps to reproduce:

Can be reproduced on `edge` branch.

### First test case:
1. On main application page select, for example, records with id `1562` and `6224` using ctrl key
(or some another records, basically it does not depend on which rows to choose).
2. Enter filter `tokyo`.
3. Select record with id `8422`  (not children) using ctrl key or just click on it.
4. Hold the swift button and click on the entry with id `6200`.

#### Expected Results:

Selected Rows: [ "8422", "5407", "6200" ]

#### Actual Result:

Selected Rows: [ "8422", "1562", "6224", "5407", "4804", "9608", "6200" ]

### Second test case:
1. On main application page select some record.
2. Enter filter `Tokyo`.
3. Select record with id `6200` using ctrl key or just click on it.
4. Hold the swift button and click on the entry with id `8422` that is lower than `6200` by two positions.

#### Expected Result:

Selected Rows: [ "6200", "5421", "8422"]

#### Actual Result:

Selected Rows: [ "8422", "5407", "5422", "8422", "1562", "6224", "5407", "4804", "9608", "6200" ]

### Third test case:
Set every city to `Tokyo`.
1. Expand first row (that has id `5422`) click on the row with id `1562`, hold shift click the bottom line, with id 5422.
2. Take a look at selected rows.
3. Try to filter by `Tokyo`.
4. Do the same as in first case.
5. The selected rows should be the same in both cases.

#### Expected Result:

Selected Rows: [ "1562", "5422" ]


### Note:

- We need to show only that records that are currently selected within the selected interval. 
- Row multi selection should works fine with `exactMatch` functionality as well.

# Definiton of Done:

- [X] Fix row multi selection.

# Internal changes:

- The current flatten rows, in `selectRow` method, are calculated depending on `isFiltering` property.
If `isFiltering` equals true, then flatten `filteredRows` otherwise `currentRows`.
- The children's rows have `_isChildren` flag to indicate that this row is children.
- If there is `exactMatch`, `isFiltering` and `areFlattenRowsHaveExactMatch`
re-order flatten rows for correct row selection. The `reOrderFlattenRows` function works simply:
the rows that don't have `children` rows come first, then come those that have ones.
The `areFlattenRowsHaveExactMatch` value calculated based on the following rules:
   1. If every item from `flatten` array has `_exactMatch` `true`, then return `false`. 
       We don't need to reOrderFlattenRows in this case.
   6. Otherwise, check if there is at least one element in the `flatten` array with
       `_exactMatch` value equal to `true`.
- Separate handlers for handling pressing shift and ctrl buttons

### Note:

Shift selection works only for one interval.

If we choose row with index 5 and then select below row, selected rows will be from 5 index to the last clicked row index. For example from 5 to 8.

If we choose row with index 5 and then select above row, selected rows will be from the last clicked row index to 5 index. For example from 3 to 5.
