### PR TITLE
Fix incorrect highlighting of exactly matched cells.

### DIFF
--- a/src/mixins/selection.js
+++ b/src/mixins/selection.js
@@ -39,6 +39,7 @@ export default {
         },
       
         resetExactMatch (row) {
+            row._meta.exactMatchColumns = [];
             if (row._children.length) {
                 row._children.forEach((childrenRow) => {
                     this.resetExactMatch(childrenRow);


### PR DESCRIPTION
# Description:

Highlighting previous exact match when filter has another value.

# Definition of Done:

- [X] Fix cells highlighting.
After clearing selection just reset set `exactMatchColumns` property to an empty array.

# Steps to reproduce:
**Note: It can be reproduced on edge branch.**

1. Start application locally
2. In the filter field enter the following value: `Tiger`.
3. The cell exactly matching the filter should has a yellow background.
4. Clear filter field.
5. In the filter field enter the following value: `Office Manager`.

# Expected result:

The cell with a value `Office Manager` has the yellow background color

# Actual result

Cells with values `Tiger` and `Office Manager` have the yellow background color.
