### PR TITLE
Extend vue-ads-table-tree table functionality: possibility to hide bottom slot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ at the top, and highlight the matching cells.
 - `start`: *(type: number, default: `undefined`)* The start index to show only a slice of the rows.
 - `end`: *(type: number, default: `undefined`)* The end index to show only a slice of the rows.
 - `has-top-slot`: *(type: boolean, default: `true`)* Render top slot with default content (filter input).
+- `has-bottom-slot`: *(type: boolean, default: `true`)* Render bottom slot with default content (pagination input).
 - `fixed-table-head`: *(type: boolean, default: `false`)* Fix table thead while scrolling.
 - `columns-resizable`: *(type: boolean, default: `false`)* Make table columns resizable.
 - `manage-table-properties`: *(type: boolean, default: `false`)* Show property manager. Allows you to control the visibility of columns.

--- a/src/TableContainerApp.vue
+++ b/src/TableContainerApp.vue
@@ -4,6 +4,7 @@
     >
         <vue-ads-table
             has-top-slot
+            has-bottom-slot
             :columns="columns"
             :rows="rows"
             :classes="classes"

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -19,7 +19,6 @@
             <table
                 :class="tableClasses"
                 class="vue-ads-w-full vue-ads-font-sans"
-                style="border-collapse: collapse;"
             >
                 <!-- TABLE HEADER -->
                 <thead>

--- a/src/components/TableContainer.vue
+++ b/src/components/TableContainer.vue
@@ -60,7 +60,7 @@
                 <slot name="no-rows"></slot>
             </template>
         </vue-ads-table>
-        <slot name="bottom"
+        <slot v-if="hasBottomSlot" name="bottom"
               :total="total"
               :page="page"
               :itemsPerPage="itemsPerPage"
@@ -189,6 +189,11 @@ export default {
         },
 
         hasTopSlot: {
+            type: Boolean,
+            default: true,
+        },
+
+        hasBottomSlot: {
             type: Boolean,
             default: true,
         },


### PR DESCRIPTION
# Definition of Done:

- [X] Added possibility to hide/show table bottom slot.

# Internal changes:

- Added new table properties that can change its behavior:
  - `has-bottom-slot` - Render bottom slot with default content (pagination input).
For example if you don't want to use default pagination you can paste that prop.