### PR TITLE
Minor fix for checkedColumns property

### DIFF
--- a/src/mixins/columns.js
+++ b/src/mixins/columns.js
@@ -74,7 +74,9 @@ export default {
         columnsChanged (columns) {
             const visibleColumns = columns.filter((column) => column.visible);
             this.initialColumns = visibleColumns;
-            this.checkedColumns = visibleColumns.map((column) => column.property);
+            if (this.manageTableProperties) {
+                this.checkedColumns = visibleColumns.map((column) => column.property);
+            }
             let maxSortOrder = this.maxSortOrder();
 
             columns.forEach(column => {


### PR DESCRIPTION
# Definition of Done:

- [X] If `manageTableProperties` prop  with a value of  `true`, only then set `checkedColumns` in `columnsChanged` method