### PR TITLE
Extend table functionality: Styles corrections for grouping and minor features/adjustments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ or a string with brackets {}, which will be parsed later, for example:
 groupBy: (value) => {
   if (value < 100000) {
     return '< 100 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
-    // It will be parsed into "< 100 000 (2 Items)"
+    // It will be parsed into "< 100 000 (2 Items),
+    // where 2 is actual groupedRows length."
   }
   return value;
 }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ or a string with brackets {}, which will be parsed later, for example:
 groupBy: (value) => {
   if (value < 100000) {
     return '< 100 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
-    // It will be parsed into "< 100 000 (2 Items),
+    // It will be parsed into "< 100 000 (2 Items)",
     // where 2 is actual groupedRows length."
   }
   return value;

--- a/README.md
+++ b/README.md
@@ -75,19 +75,21 @@ groupBy: (value) => {
   return value;
 }
 ```    
-or a string with brackets {}, which will be parsed later, for example:
+or a string with reserved variables in brackets {}, which will be parsed in the usual string, for example:
 ```js
 groupBy: (value) => {
   if (value < 100000) {
     return '< 100 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
-    // It will be parsed into "< 100 000 (2 Items)",
-    // where 2 is actual groupedRows length."
+    // It will be parsed into "< 100 000 (N Items)",
+    // where `N` is actual groupedRows length.
+    // Notice that string interpolation supports pluralization,
+    // you can use optional operator to detect what number is singular or plural."
   }
   return value;
 }
 ```
-At the moment, you can pass the `rowsLength` property into brackets and do any calculations with it.
-The `rowsLength` property is reserved.
+The following reserved properties can be passed into string:
+- `rowsLength` - describes the length of grouped rows by specific column.
 
 ### <a name="rows"></a>Rows
 Rows are listed in a row array as plain objects. Each object contains the row data and meta data. Meta data is prefixed with a `_`:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,27 @@ Columns are listed in a column array as plain objects and can have the following
 - `hideOnGroup`: *(type: boolean, default: `true` if no `groupedBy` property is set)* Hide the column if the rows are grouped by this column.
 - `groupBy`: *(type: Function)* This function convert the cell value to another value. The row will be grouped by the returned value.
 It has one parameter:
-    - `value`: *(type: mixed)* The default cell value.
+    - `value`: *(type: mixed)* The default cell value.  The `groupBy` function can return just usual string like
+```js
+groupBy: (value) => {
+  if (value < 100000) {
+    return '< 100 000';
+  }
+  return value;
+}
+```    
+or a string with brackets {}, which will be parsed later, for example:
+```js
+groupBy: (value) => {
+  if (value < 100000) {
+    return '< 100 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
+    // It will be parsed into "< 100 000 (2 Items)"
+  }
+  return value;
+}
+```
+At the moment, you can pass the `rowsLength` property into brackets and do any calculations with it.
+The `rowsLength` property is reserved.
 
 ### <a name="rows"></a>Rows
 Rows are listed in a row array as plain objects. Each object contains the row data and meta data. Meta data is prefixed with a `_`:

--- a/src/TableContainerApp.vue
+++ b/src/TableContainerApp.vue
@@ -283,15 +283,15 @@ export default {
                 groupable: true,
                 groupBy: (budget) => {
                     if (budget < 100000) {
-                        return '< 100 000';
+                        return '< 100 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
                     } else if (budget < 200000) {
-                        return '< 200 000';
+                        return '< 200 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
                     } else if (budget < 300000) {
-                        return '< 300 000';
+                        return '< 300 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
                     } else if (budget < 400000) {
-                        return '< 400 000';
+                        return '< 400 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
                     } else {
-                        return '> 400 000';
+                        return '> 400 000 ({rowsLength} Item{rowsLength > 1 ? "s" : ""})';
                     }
                 },
             },

--- a/src/components/HeaderCell.vue
+++ b/src/components/HeaderCell.vue
@@ -40,18 +40,16 @@ export default {
             type: Boolean,
             default: false,
         },
+
+        haveRows: {
+            type: Boolean,
+            default: false,
+        },
     },
 
     computed: {
         headerClasses () {
             return Object.assign(
-                {
-                    'vue-ads-cursor-pointer': [
-                        null,
-                        true,
-                        false,
-                    ].includes(this.column.direction) && this.sortable,
-                },
                 this.cssProcessor.process(null, this.columnIndex),
                 this.cssProcessor.process(0, this.columnIndex),
                 {
@@ -108,7 +106,10 @@ export default {
                     on: {
                         click: (event) => {
                             event.stopPropagation();
-                            this.$emit('group', this.column);
+                            // If there are no rows, don't group by column.
+                            if (this.haveRows) {
+                                this.$emit('group', this.column);
+                            }
                         },
                     },
                 }
@@ -127,7 +128,13 @@ export default {
                     {
                         class: {
                             'vue-ads-flex': true,
-                            'vue-ads-mr-2': this.columnsResizable,
+                            'vue-ads-items-center': true,
+                            'vue-ads-mr-3': this.columnsResizable,
+                            'vue-ads-cursor-pointer': [
+                                null,
+                                true,
+                                false,
+                            ].includes(this.column.direction) && this.sortable,
                         },
                         on: {
                             click: (event) => {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -10,8 +10,8 @@
                     v-if="isTablePropertiesVisible"
                     :content-classes="cssProcessor.classes.manageProperties"
                     :columns="initialColumns"
-                    v-model="checkedColumns"
-                    @setCheckedColumns="setCheckedColumns"
+                    v-model="checkedTableProperties"
+                    @setCheckedTableProperties="setCheckedTableProperties"
                 />
             </div>
         </div>
@@ -35,6 +35,7 @@
                             :css-processor="cssProcessor"
                             :sort-icon-slot="sortIconSlot"
                             :columns-resizable="columnsResizable"
+                            :have-rows="haveRows"
                             @sort="sort"
                             @group="group"
                         >

--- a/src/components/TableProperties.vue
+++ b/src/components/TableProperties.vue
@@ -5,11 +5,11 @@
             <div class="vue-ads-ml-3 vue-ads-mt-2 vue-ads-mr-2">
                 <div class="vue-ads-mt-1 vue-ads-flex" v-for="column of transformedColumns" :key="column.property">
                     <input
+                        v-model="selectedColumns"
                         type="checkbox"
                         :id="column.property"
                         :value="column.property"
-                        v-model="selectedColumns"
-                        :disabled="selectedColumns.length === 1 && selectedColumns[0] === column.property"
+                        :disabled="column.disabled"
                     >
                     <label
                         class="vue-ads-ml-2"
@@ -53,6 +53,9 @@ export default {
     computed: {
         transformedColumns () {
             return this.columns.map((column) => {
+                column.disabled =
+                    column.grouped ||
+                    this.selectedColumns.length === 1 && this.selectedColumns[0] === column.property;
                 column.shortTitle = column.title.length > COLUMN_TITLE_PROPERTY_LENGTH_LIMIT
                     ? `${column.title.slice(0, COLUMN_TITLE_PROPERTY_LENGTH_LIMIT)}...`
                     : column.title;

--- a/src/components/TableProperties.vue
+++ b/src/components/TableProperties.vue
@@ -3,9 +3,9 @@
         <div class="vue-ads-properties-card vue-ads-mt-3 vue-ads-absolute vue-ads-shadow-2xl" :class="contentClasses">
             <span>Properties</span>
             <div class="vue-ads-ml-3 vue-ads-mt-2 vue-ads-mr-2">
-                <div class="vue-ads-mt-1 vue-ads-flex" v-for="column of transformedColumns" :key="column.property">
+                <div class="vue-ads-mt-1 vue-ads-flex" v-for="column of transformedTablePropertyColumns" :key="column.property">
                     <input
-                        v-model="selectedColumns"
+                        v-model="selectedTablePropertyColumns"
                         type="checkbox"
                         :id="column.property"
                         :value="column.property"
@@ -47,15 +47,18 @@ export default {
     },
     data () {
         return {
-            selectedColumns: [],
+            selectedTablePropertyColumns: [],
         };
     },
     computed: {
-        transformedColumns () {
+        transformedTablePropertyColumns () {
             return this.columns.map((column) => {
+                // If the column is grouped or the last checked column from the list is left,
+                // the column should be disabled.
                 column.disabled =
                     column.grouped ||
-                    this.selectedColumns.length === 1 && this.selectedColumns[0] === column.property;
+                    (this.selectedTablePropertyColumns.length === 1 &&
+                    this.selectedTablePropertyColumns[0] === column.property);
                 column.shortTitle = column.title.length > COLUMN_TITLE_PROPERTY_LENGTH_LIMIT
                     ? `${column.title.slice(0, COLUMN_TITLE_PROPERTY_LENGTH_LIMIT)}...`
                     : column.title;
@@ -66,11 +69,11 @@ export default {
     watch: {
         value: {
             handler (val) {
-                this.selectedColumns = val;
+                this.selectedTablePropertyColumns = val;
             },
             immediate: true,
         },
-        selectedColumns (val) {
+        selectedTablePropertyColumns (val) {
             this.$emit('setCheckedTableProperties', val);
         },
     },

--- a/src/components/TableProperties.vue
+++ b/src/components/TableProperties.vue
@@ -68,7 +68,7 @@ export default {
             immediate: true,
         },
         selectedColumns (val) {
-            this.$emit('setCheckedColumns', val);
+            this.$emit('setCheckedTableProperties', val);
         },
     },
 };
@@ -77,5 +77,6 @@ export default {
 <style scoped>
 .vue-ads-properties-card {
   right: 0.5rem;
+  width: max-content;
 }
 </style>

--- a/src/mixins/cell/cell.js
+++ b/src/mixins/cell/cell.js
@@ -74,6 +74,9 @@ export default {
         },
 
         parent () {
+            // Initially it should be equal to `_meta.parent` value,
+            // to show nesting level for child rows,
+            // otherwise first child rows are at same level as a parent row.
             let parent = this.row._meta.parent;
 
             if (this.columnIndex === 0) {

--- a/src/mixins/cell/cell.js
+++ b/src/mixins/cell/cell.js
@@ -74,7 +74,7 @@ export default {
         },
 
         parent () {
-            let parent = 0;
+            let parent = this.row._meta.parent;
 
             if (this.columnIndex === 0) {
                 parent += this.row._meta.groupParent;

--- a/src/mixins/cell/sortCell.js
+++ b/src/mixins/cell/sortCell.js
@@ -16,7 +16,7 @@ export default {
         },
 
         sortIconClasses () {
-            if (!this.sortable || this.column.grouped) {
+            if (!this.sortable) {
                 return {};
             }
 
@@ -45,6 +45,14 @@ export default {
 
             return createElement(
                 'span',
+                {
+                    on: {
+                        click: (event) => {
+                            event.stopPropagation();
+                            this.$emit('sort', this.column);
+                        },
+                    },
+                },
                 [
                     iconNode,
                 ]

--- a/src/mixins/columns.js
+++ b/src/mixins/columns.js
@@ -10,7 +10,7 @@ export default {
     data () {
         return {
             initialColumns: [],
-            checkedColumns: [],
+            checkedTableProperties: [],
         };
     },
     watch: {
@@ -18,7 +18,7 @@ export default {
             handler: 'columnsChanged',
             immediate: true,
         },
-        checkedColumns (columns) {
+        checkedTableProperties (columns) {
             this.initialColumns = this.initialColumns.map((column) => {
                 column.visible = Boolean(columns.find((checkedColumnProperty) => checkedColumnProperty === column.property));
                 return column;
@@ -67,15 +67,15 @@ export default {
     },
 
     methods: {
-        setCheckedColumns (checkedColumns) {
-            this.checkedColumns = checkedColumns;
+        setCheckedTableProperties (checkedTableProperties) {
+            this.checkedTableProperties = checkedTableProperties;
         },
 
         columnsChanged (columns) {
             const visibleColumns = columns.filter((column) => column.visible);
             this.initialColumns = visibleColumns;
             if (this.manageTableProperties) {
-                this.checkedColumns = visibleColumns.map((column) => column.property);
+                this.checkedTableProperties = visibleColumns.map((column) => column.property);
             }
             let maxSortOrder = this.maxSortOrder();
 

--- a/src/mixins/groupBy.js
+++ b/src/mixins/groupBy.js
@@ -69,7 +69,9 @@ export default {
         },
 
         createGroupRow (value, column, groupedRows, groupLength, groupColumnIndex) {
-            groupedRows.forEach(row => row._meta.groupParent = groupColumnIndex);
+            groupedRows.forEach(groupedRow => {
+                groupedRow._meta.groupParent = groupColumnIndex;
+            });
             groupedRows = this.groupingRows(groupedRows, groupColumnIndex);
 
             let groupRow = {
@@ -86,6 +88,13 @@ export default {
 
         async group (column) {
             column.grouped = !column.grouped;
+            if (!column.grouped) {
+                // When column is not grouped, we need to reset `groupParent` value
+                // that we set before in `createGroupRow` method, to avoid unexpected row style issue.
+                this.rows.forEach((row) => {
+                    row._meta.groupParent = 0;
+                });
+            }
             column.direction = column.grouped ? !column.direction : null;
             column.order = this.maxSortOrder() + 1;
 

--- a/src/mixins/groupBy.js
+++ b/src/mixins/groupBy.js
@@ -1,5 +1,7 @@
 // TODO how to handle grouped data for async data
 
+import { interpolateStr } from '@/utils/utils';
+
 export default {
     data () {
         return {
@@ -74,6 +76,12 @@ export default {
             });
             groupedRows = this.groupingRows(groupedRows, groupColumnIndex);
 
+            if (column.groupBy instanceof Function) {
+                value = interpolateStr(value, {
+                    rowsLength: groupedRows.length,
+                });
+            }
+            
             let groupRow = {
                 [column.property]: value,
                 _children: groupedRows,

--- a/src/mixins/groupBy.js
+++ b/src/mixins/groupBy.js
@@ -89,10 +89,14 @@ export default {
         async group (column) {
             column.grouped = !column.grouped;
             if (!column.grouped) {
-                // When column is not grouped, we need to reset `groupParent` value
-                // that we set before in `createGroupRow` method, to avoid unexpected row style issue.
+                //  If column is not grouped, but it was grouped previously, we need to reset groupParent value,
+                //  that we set in `createGroupRow` method before, to avoid rows style issue after ungrouping.
+                //  Based on `groupParent` value we add `padding-left` to rows (see the `parent` computed property in `cell.js` file)
+                //  to show nesting level.
                 this.rows.forEach((row) => {
-                    row._meta.groupParent = 0;
+                    if (row._meta.groupParent > 0) {
+                        row._meta.groupParent = 0;
+                    }
                 });
             }
             column.direction = column.grouped ? !column.direction : null;

--- a/src/mixins/rows.js
+++ b/src/mixins/rows.js
@@ -24,6 +24,10 @@ export default {
         loadedRows () {
             return this.rows.filter(row => row);
         },
+
+        haveRows () {
+            return Boolean(this.rows.length);
+        },
     },
 
     methods: {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -10,7 +10,7 @@ export function isValidDate (value) {
 /**
  * Executes passed code.
  * @param {String} code - Code that should be executed.
- * @returns {*}
+ * @returns {*} - The result of the executed code.
  */
 export function evalCode (code) {
     return new Function(`return ${code}`)();
@@ -21,7 +21,9 @@ export function evalCode (code) {
  * Can parse variables / ternary condition passed in {} brackets.
  * In the future, this function can be improved, this is just an example,
  * so that it is possible to pass variables that need to be parsed in a string.
- * @returns {function(*, *): *}
+ * @param {String} str - The string that should be interpolated.
+ * @param {Object} data - An object that contains the property keys to be interpolated.
+ * @returns {String} - Interpolated string.
  */
 export function interpolateStr (str, data) {
     const regexp = /{([^{]+)}/g;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -32,6 +32,6 @@ export function interpolateStr (str, data) {
             splitKey[0] = data[splitKey[0]];
             return evalCode(splitKey.join(' '));
         }
-        return (key = data[key]) == null ? '' : key;
+        return (key = data[key]) === null ? '' : key;
     });
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -6,3 +6,32 @@
 export function isValidDate (value) {
     return Boolean(Date.parse(value));
 }
+
+/**
+ * Executes passed code.
+ * @param {String} code - Code that should be executed.
+ * @returns {*}
+ */
+export function evalCode (code) {
+    return new Function(`return ${code}`)();
+}
+
+/**
+ * Interpolate string variables.
+ * Can parse variables / ternary condition passed in {} brackets.
+ * In the future, this function can be improved, this is just an example,
+ * so that it is possible to pass variables that need to be parsed in a string.
+ * @returns {function(*, *): *}
+ */
+export function interpolateStr (str, data) {
+    const regexp = /{([^{]+)}/g;
+    return str.replace(regexp, (ignore, key) => {
+        // Check if key includes ternary operation.
+        if (key.includes('>') && key.includes('?') && key.includes(':')) {
+            const splitKey = key.split(' ');
+            splitKey[0] = data[splitKey[0]];
+            return evalCode(splitKey.join(' '));
+        }
+        return (key = data[key]) == null ? '' : key;
+    });
+}


### PR DESCRIPTION
# Definition of Done:

- [X] Corrections for group by functionality.
**Note:** These are just style fixes to existing group functionality, but not a re-work of the current grouping functionality.
- [X] Added possibility to display the count of grouped rows by parsing passed string in groupBy callback.

# Internal changes:

- If there are no table rows and you click on the column to group, don't emit `group` 
event to group table rows by column because it can lead to the problem
when you can not do ungroup.
A corresponding computed property (`haveRows`) has been added for this change.
- If column is not grouped but it was grouped previously, we need to reset `groupParent` value,
that we set in `createGroupRow` method before, to avoid rows style issue after ungrouping.
Based on `groupParent` value we add `padding-left` to rows
(see the `parent` computed property in `cell.js` file) to show nesting level.
- Grouped row has sort icon, as before.
- Changes for header cell classes:
    - Has `cursor-pointe` class, if:
        - The column is sortable.
        - The column has direction point.
- The `TableProperties` component has been refactored:
    - The reactive `checkedColumns` model was renamed to `checkedTableProperties`, to make it clearer what this variable is about.
    - The `setCheckedColumns` method was renamed to `setCheckedTableProperties`.
    - The `selectedColumns` model name was renamed to `selectedTablePropertyColumns`.
    - The `transformedColumns ` method was renamed to `transformedTablePropertyColumns`.
- Added two new utils functions:
    - `evalCode` - Allows to executed the passed code as string.
    - `interpolateStr` - Allows to parse string with `{}` brackets.
- In `createGroupRow` method call the column groupBy method for string interpolation.
String interpolation is a good approach for `groupBy` method since we can not paste `groupedRows.length` to `groupBy` callback function in `rowValue` method, because on that moment we don't know the actual size of grouped rows, and we risk to paste the `undefined` value to callback that is not correct.
- If the column is grouped, you can not hide this column using table properties manager, since in this way we can not group rows by hidden row. We can re-work this logic in order we could hide grouped column, but I think it can take a decent amount of time, since it will be necessary to pass the current grouping logic.
In `transformedColumns` computed property (`TableProperties.vue` file) added `disabled` property to the `column`, that calculates whether the column is disabled or not.

Wrong styles after ungrouping can be noticed on `edge` branch, also on the `develop` branch, which is the stable branch of this library. Also you could notice that if the column is grouped  and you want to show the nested rows of some row, nested items would be at the same level as parent row. It is strange that this problem was not noticed earlier.
For example, on `edge` or `develop` branch to reproduce the problem  you could do the following steps:

1. Run app locally.
2. Group table rows by `Function` column (click on the icon to the right of the sort icon).
3. Ungroup rows.
4. The lines are indented chaotically on the left, this can be seen from the first column.
5. Group rows by `Function` column.
6. Scroll to the `Office Manager` grouped row.
7. Click on the "expand" icon of the row with id `5421`.
8. You can see that first child rows (rows with id `8422` and `5407`) at same level as the row with id `5421`, that does not correct.

# Testing Done:

1. Run app locally.
2. Group table rows by `Function` column (click on the icon to the right of the sort icon).
3. Ungroup rows.
4. Rows should return to their previous position (as they were before sorting).
5. Group rows by `Function column`.
6. Scroll to the `Office Manager` grouped row.
7. Click on the row with a value of `5421`.
8. You should see child elements showing the nested level.
9. Group rows by some column.
10. Open table properties manager.
11. The column by which the rows were grouped should disabled (not be clickable).
